### PR TITLE
Adding support for the new `batch` parameter for bucket.all

### DIFF
--- a/simperium/core.py
+++ b/simperium/core.py
@@ -289,7 +289,7 @@ class Bucket(object):
             raise
         return json.loads(response.read())
 
-    def all(self, cv=None, data=False, username=False, most_recent=False, timeout=None, skip_clientids=[], batch):
+    def all(self, cv=None, data=False, username=False, most_recent=False, timeout=None, skip_clientids=[], batch=None):
         """retrieves *all* updates for this bucket, regardless of the user
             which made the update.
 

--- a/simperium/core.py
+++ b/simperium/core.py
@@ -309,11 +309,6 @@ class Bucket(object):
                 is supplied an empty list will be return if no updates are made
                 before the timeout is reached.
         """
-        try:
-            batch = int(batch)
-        except:
-            batch = 100
-
         url = '%s/%s/all?clientid=%s' % (
             self.appname, self.bucket, self.clientid)
         if cv is not None:
@@ -326,8 +321,10 @@ class Bucket(object):
             url += '&most_recent=1'
         for clientid in skip_clientids:
             url += '&skip_clientid=%s' % urllib.quote_plus(clientid)
-        if batch != 100:
-            url += '&batch=%d' % batch
+        try:
+            url += '&batch=%d' % int(batch)
+        except:
+            url += '&batch=100'
         headers = self._auth_header()
         try:
             response = self._request(url, headers=headers, timeout=timeout)

--- a/simperium/core.py
+++ b/simperium/core.py
@@ -286,7 +286,7 @@ class Bucket(object):
             raise
         return json.loads(response.read())
 
-    def all(self, cv=None, data=False, username=False, most_recent=False, timeout=None, skip_clientids=[]):
+    def all(self, cv=None, data=False, username=False, most_recent=False, timeout=None, skip_clientids=[], batch=100):
         """retrieves *all* updates for this bucket, regardless of the user
             which made the update.
 
@@ -309,6 +309,11 @@ class Bucket(object):
                 is supplied an empty list will be return if no updates are made
                 before the timeout is reached.
         """
+        try:
+            batch = int(batch)
+        except:
+            batch = 100
+
         url = '%s/%s/all?clientid=%s' % (
             self.appname, self.bucket, self.clientid)
         if cv is not None:
@@ -321,6 +326,8 @@ class Bucket(object):
             url += '&most_recent=1'
         for clientid in skip_clientids:
             url += '&skip_clientid=%s' % urllib.quote_plus(clientid)
+        if batch != 100:
+            url += '&batch=%d' % batch
         headers = self._auth_header()
         try:
             response = self._request(url, headers=headers, timeout=timeout)

--- a/simperium/core.py
+++ b/simperium/core.py
@@ -75,6 +75,9 @@ class Bucket(object):
         >>> bucket.get('item2', version=1)
         {'age': 23}
     """
+
+    BATCH_DEFAULT_SIZE = 100
+
     def __init__(self, appname, auth_token, bucket,
             userid=None,
             host=None,
@@ -286,7 +289,7 @@ class Bucket(object):
             raise
         return json.loads(response.read())
 
-    def all(self, cv=None, data=False, username=False, most_recent=False, timeout=None, skip_clientids=[], batch=100):
+    def all(self, cv=None, data=False, username=False, most_recent=False, timeout=None, skip_clientids=[], batch):
         """retrieves *all* updates for this bucket, regardless of the user
             which made the update.
 
@@ -324,7 +327,7 @@ class Bucket(object):
         try:
             url += '&batch=%d' % int(batch)
         except:
-            url += '&batch=100'
+            url += '&batch=%d' % self.BATCH_DEFAULT_SIZE
         headers = self._auth_header()
         try:
             response = self._request(url, headers=headers, timeout=timeout)


### PR DESCRIPTION
Adds the `batch` parameter to the bucket.all endpoint call, if one is provided.